### PR TITLE
Use the correct AsyncSessionTransaction type for .transaction()

### DIFF
--- a/src/sqlalchemy_tx_context/context.py
+++ b/src/sqlalchemy_tx_context/context.py
@@ -15,7 +15,7 @@ from sqlalchemy.engine import Result
 from sqlalchemy.engine.interfaces import (
     _CoreAnyExecuteParams,  # type: ignore[reportPrivateUsage]
 )
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, AsyncSessionTransaction, async_sessionmaker
 from sqlalchemy.orm._typing import (
     OrmExecuteOptionsParameter,  # type: ignore[reportPrivateUsage]
 )
@@ -128,7 +128,7 @@ class SQLAlchemyTransactionContext:
         session_maker: Optional[async_sessionmaker[AsyncSession]] = None,
         reuse_if_exists: bool = True,
         allow_nested_transactions: bool = True,
-    ) -> AsyncIterator[AsyncSession]:
+    ) -> AsyncIterator[AsyncSessionTransaction]:
         """
         Enter a transaction context. Creates a new session if needed.
 


### PR DESCRIPTION
Hi, thanks for creating this amazing package! This is an essential pice that helps to build proper layer isolation, and implement a usable (no passing the session/context in every function call) Unit-of-Work pattern. It's something I have always had to implement internally at work. 

---

There's a small typing issue, which I believe my PR addresses:

Both `session.begin()` and `session.begin_nested()` return `AsyncSessionTransaction`, not `AsyncSession`. 

Although we benefit from them having similar interface due to duck typing, they are not interchangeable types in SQLAlchemy design.